### PR TITLE
live/create: Fix docs about `profiles` field

### DIFF
--- a/docs/guides/livestreaming/create-a-stream.mdx
+++ b/docs/guides/livestreaming/create-a-stream.mdx
@@ -52,13 +52,14 @@ Livepeer Studio `stream` object.
 
 Use a Livepeer Studio API key as a part of the authorization header, and use a JSON
 body to specify the configuration for the stream. The only parameter you are
-required to set is the `name` of your stream, but we also highly recommend that
-you define the `profiles` parameter with 720p, 480p and 360p renditions.
+required to set is the `name` of your stream.
 
 If you do not define transcoding rendition `profiles` when creating the
-`stream`, no transcoding will happen. Your playback video will have the
-attributes of the source stream only, will not take advantage of adaptive
-bitrate streaming, and will likely buffer.
+`stream`, a default set of profiles will be used with 720p, 480p, 360p and 240p
+renditions. To disable transcoding for your stream you have to explicitly set an
+empty array of `profiles` in your stream object. Beware that in that setup, your
+playback video will have the attributes of the source stream only and will not
+take advantage of adaptive bitrate streaming, likely buffering on playback.
 
 ### Request
 


### PR DESCRIPTION
Changed it at some point in the API but the docs
stayed outdated.

Fixes https://github.com/livepeer/studio/issues/1146