### PR TITLE
change data to body on line 48

### DIFF
--- a/docs/05-reference/api/create-asset.mdx
+++ b/docs/05-reference/api/create-asset.mdx
@@ -45,7 +45,7 @@ const response = await fetch("https://livepeer.studio/api/asset/request-upload",
       Authorization: "Bearer {api_key}",
       "Content-Type": "application/json",
     },
-    data: JSON.stringify({
+    body: JSON.stringify({
       name: "Example name",
     }),
   })


### PR DESCRIPTION
On line 48 `data` does not work, returns a 422 error, and switching it to `body` works. https://discord.com/channels/423160867534929930/426114749370204170/1021731271312932895 https://discord.com/channels/423160867534929930/426114749370204170/1021787388458053642