### PR TITLE
on-demand/upload: Remove unnecessary headers in example

### DIFF
--- a/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
@@ -165,12 +165,8 @@ Using the URL generated in the response, upload your video with a PUT request.
 
 ```js
 await fetch(url, {
-    method: "PUT",
-    headers: {
-        Authorization: `Bearer ${process.env.LP_API_KEY}`
-        "Content-Type": "video/mp4"
-    },
-    body: fs.createReadStream(path)
+  method: "PUT",
+  body: fs.createReadStream(path),
 });
 ```
 
@@ -179,7 +175,6 @@ await fetch(url, {
 
 ```bash
 curl --location --request PUT "${url}" \
---header 'Content-Type: video/mp4' \
 --data-binary '@$VIDEO_FILE_PATH'
 ```
 


### PR DESCRIPTION
It will only confuse users to add headers that are not necessary.

The authorization one is the biggest problem tho, as it would effectively direct developers into doing the upload from their backend instead of directly from the frontend with the pre-signed URL.