### PR TITLE
Fix description of create webhook response

### DIFF
--- a/docs/04-guides/listen-for-webhooks.mdx
+++ b/docs/04-guides/listen-for-webhooks.mdx
@@ -70,8 +70,8 @@ curl \
 
 ### Response
 
-Returns a JSON object with the `events`, stream `id`, `name` of the webhook,
-`url` of the webhook endpoint, and the `userID` of the stream
+Returns a JSON object with the webhook object just created. This includes its `id`, `name`, the `events` it will be notified about and
+the `url` that will be called.
 
 ```JSON
 {


### PR DESCRIPTION
There is no stream object there. It's only a created webhook and the information about it.