### PR TITLE
Update 01-create-a-livestream.mdx

### DIFF
--- a/docs/04-guides/live/01-create-a-livestream.mdx
+++ b/docs/04-guides/live/01-create-a-livestream.mdx
@@ -72,21 +72,18 @@ curl -X POST \
     {
       "name": "720p",
       "bitrate": 2000000,
-      "fps": 30,
       "width": 1280,
       "height": 720
     },
     {
       "name": "480p",
       "bitrate": 1000000,
-      "fps": 30,
       "width": 854,
       "height": 480
     },
     {
       "name": "360p",
       "bitrate": 500000,
-      "fps": 30,
       "width": 640,
       "height": 360
     }


### PR DESCRIPTION
Remove fps setting because people stream in all kinds of fps, and we should default it to 0.