### PR TITLE
Update 01-create-a-livestream.mdx

### DIFF
--- a/docs/04-guides/live/01-create-a-livestream.mdx
+++ b/docs/04-guides/live/01-create-a-livestream.mdx
@@ -72,21 +72,21 @@ curl -X POST \
     {
       "name": "720p",
       "bitrate": 2000000,
-      "fps": 30,
+      "fps": 0,
       "width": 1280,
       "height": 720
     },
     {
       "name": "480p",
       "bitrate": 1000000,
-      "fps": 30,
+      "fps": 0,
       "width": 854,
       "height": 480
     },
     {
       "name": "360p",
       "bitrate": 500000,
-      "fps": 30,
+      "fps": 0,
       "width": 640,
       "height": 360
     }
@@ -106,9 +106,9 @@ the live stream.
 {
     "name":"test_stream",
     "profiles":[
-        {"name":"720p","bitrate":2000000,"fps":30,"width":1280,"height":720},
-        {"name":"480p","bitrate":1000000,"fps":30,"width":854,"height":480},
-        {"name":"360p","bitrate":500000,"fps":30,"width":640,"height":360},
+        {"name":"720p","bitrate":2000000,"fps":0,"width":1280,"height":720},
+        {"name":"480p","bitrate":1000000,"fps":0,"width":854,"height":480},
+        {"name":"360p","bitrate":500000,"fps":0,"width":640,"height":360},
       ],
     "id":"ijkl61f3-95bd-4971-a7b1-4dcb5d39e78a",
     "createdAt":1596081229373,


### PR DESCRIPTION
Remove fps setting because people stream in all kinds of fps, and we should default it to 0.