### PR TITLE
FPS recommendation

### DIFF
--- a/docs/04-guides/live/08-configure-broadcast-software.mdx
+++ b/docs/04-guides/live/08-configure-broadcast-software.mdx
@@ -66,21 +66,21 @@ When you create a `stream` object with a `POST` request to `/api/stream`
     {
       "name": "720p",
       "bitrate": 2000000,
-      "fps": 30,
+      "fps": 0,
       "width": 1280,
       "height": 720
     },
     {
       "name": "480p",
       "bitrate": 1000000,
-      "fps": 30,
+      "fps": 0,
       "width": 854,
       "height": 480
     },
     {
       "name": "360p",
       "bitrate": 500000,
-      "fps": 30,
+      "fps": 0,
       "width": 640,
       "height": 360
     }


### PR DESCRIPTION
Updates FPS recommendation to zero to ensure passthrough. This issue surfaced because we had several users run into problems due to FPS mismatches