### PR TITLE
docs: update codeblocks in livepeer studio docs to reflect sdk documentation

### DIFF
--- a/docs/04-guides/get-viewer-engagement/02-api.mdx
+++ b/docs/04-guides/get-viewer-engagement/02-api.mdx
@@ -38,7 +38,7 @@ asset yet, you can follow the
 Once you have the `asset.id`, you can make a request to get the viewership data.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
 
 ```js
 import {
@@ -64,7 +64,7 @@ function App() {
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const response = await fetch(

--- a/docs/04-guides/get-viewer-engagement/02-api.mdx
+++ b/docs/04-guides/get-viewer-engagement/02-api.mdx
@@ -52,6 +52,32 @@ asset yet, you can follow the
 Once you have the `asset.id`, you can make a request to get the viewership data.
 
 <CodeBlockTabs>
+<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+
+```js
+import {
+  LivepeerConfig,
+  createReactClient,
+  studioProvider,
+  useAssetMetrics
+} from '@livepeer/react';
+ 
+const client = createReactClient({
+  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
+});
+ 
+function App() {
+  const { data: metrics } = useAssetMetrics({ assetId });
+ 
+  return (
+    <LivepeerConfig client={client}>
+      <p>Metrics: {metrics}</p>
+    </LivepeerConfig>
+  ) 
+}
+```
+
+</CodeBlockTabItem>
 <CodeBlockTabItem value="JavaScript" label="JavaScript">
 
 ```js

--- a/docs/04-guides/get-viewer-engagement/02-api.mdx
+++ b/docs/04-guides/get-viewer-engagement/02-api.mdx
@@ -95,12 +95,4 @@ const { startViews } = await response.json()
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request GET https://livepeer.studio/api/data/views/{assetId}/total \
-    -H "Authorization: Bearer $API_TOKEN"
-```
-
-</CodeBlockTabItem>
 </CodeBlockTabs>

--- a/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
@@ -217,6 +217,75 @@ curl --location --request GET 'https://livepeer.studio/api/asset/{id}' \
 </CodeBlockTabItem>
 </CodeBlockTabs>
 
+### Using Livepeerjs
+
+You can also use [Livepeerjs](https://livepeerjs.org/) to upload a video asset directly to Livepeer.
+
+<CodeBlockTabs>
+<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+
+```js
+import {
+  LivepeerConfig,
+  createReactClient,
+  studioProvider,
+  useAsset, 
+  useCreateAsset
+} from '@livepeer/react';
+ 
+const client = createReactClient({
+  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
+});
+ 
+function App() {
+  const [video, setVideo] = useState<File | undefined>();
+  const {
+    mutate: createAsset,
+    data: asset,
+    uploadProgress,
+    status,
+    error,
+  } = useCreateAsset();
+ 
+  return (
+    <LivepeerConfig client={client}>
+      <div>
+        <input
+          type="file"
+          accept="video/*"
+          onChange={(e) => setVideo(e?.target?.files?.[0])}
+        />
+        <button
+          disabled={!video || status === 'loading'}
+          onClick={() => {
+            if (video) {
+              createAsset({
+                name: video.name,
+                file: video,
+              });
+            }
+          }}
+        >
+          Create Asset
+        </button>
+        {asset && (
+          <>
+            <div>Asset Name: {asset?.name}</div>
+            <div>Playback URL: {asset?.playbackUrl}</div>
+            {uploadProgress && <div>Upload Progress: {Math.floor(uploadProgress * 100)}%</div>}
+            {asset?.status?.progress && <div>Processing Progress: {Math.floor(asset.status.progress * 100)}%</div>}
+          </>
+        )}
+        {error && <div>{error.message}</div>}
+      </div>
+    </LivepeerConfig>
+  ) 
+}
+```
+
+</CodeBlockTabItem>
+</CodeBlockTabs>
+
 ## Resumable Upload
 
 A resumable upload allows you to resume an upload operation after a

--- a/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
@@ -38,7 +38,20 @@ To upload the asset to the Livepeer network, you'll need to make a POST request
 and include the URL of the asset to be uploaded.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
+
+```js
+import { useCreateAsset } from '@livepeer/react';
+ 
+function App() {
+  const { mutate: createAsset, status } = useCreateAsset({
+    sources: [{ name: "test", url: "https://test.com"  }] as const,
+  });
+}
+```
+
+</CodeBlockTabItem>
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const uploadAssetURL = await fetch("https://livepeer.studio/api/asset/import", {
@@ -69,7 +82,18 @@ returned in the response, the asset is not available yet and you should make the
 API call again until `asset.status: "ready"`.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
+
+```js
+import { useAsset } from '@livepeer/react';
+ 
+function App() {
+  const { data: asset, status } = useAsset(asset?.id);
+}
+```
+
+</CodeBlockTabItem>
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const response = await fetch("https://livepeer.studio/api/asset/{id}", {
@@ -100,7 +124,7 @@ To upload the asset to the Livepeer network locally, you'll need to make a POST
 request to generate an upload URL.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const response = await fetch(
@@ -128,7 +152,20 @@ const { url } = await response.json();
 Using the URL generated in the response, upload your video with a PUT request.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
+
+```js
+import { useCreateAsset } from '@livepeer/react';
+ 
+function App() {
+  const { mutate: createAsset, status } = useCreateAsset({
+    sources: [{ name: "test", file: video  }] as const,
+  });
+}
+```
+
+</CodeBlockTabItem>
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const upload = await fetch(url, {
@@ -152,7 +189,18 @@ returned in the response, the asset is not available yet and you should make the
 API call again until `asset.status: "ready"`.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
+
+```js
+import { useAsset } from '@livepeer/react';
+ 
+function App() {
+  const { data: asset, status } = useAsset(asset?.id);
+}
+```
+
+</CodeBlockTabItem>
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const response = await fetch("https://livepeer.studio/api/asset/{id}", {
@@ -163,75 +211,6 @@ const response = await fetch("https://livepeer.studio/api/asset/{id}", {
 });
 
 const { status } = await response.json();
-```
-
-</CodeBlockTabItem>
-</CodeBlockTabs>
-
-### Using Livepeerjs
-
-You can also use [Livepeerjs](https://livepeerjs.org/) to upload a video asset directly to Livepeer.
-
-<CodeBlockTabs>
-<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
-
-```js
-import {
-  LivepeerConfig,
-  createReactClient,
-  studioProvider,
-  useAsset, 
-  useCreateAsset
-} from '@livepeer/react';
- 
-const client = createReactClient({
-  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
-});
- 
-function App() {
-  const [video, setVideo] = useState<File | undefined>();
-  const {
-    mutate: createAsset,
-    data: asset,
-    uploadProgress,
-    status,
-    error,
-  } = useCreateAsset();
- 
-  return (
-    <LivepeerConfig client={client}>
-      <div>
-        <input
-          type="file"
-          accept="video/*"
-          onChange={(e) => setVideo(e?.target?.files?.[0])}
-        />
-        <button
-          disabled={!video || status === 'loading'}
-          onClick={() => {
-            if (video) {
-              createAsset({
-                name: video.name,
-                file: video,
-              });
-            }
-          }}
-        >
-          Create Asset
-        </button>
-        {asset && (
-          <>
-            <div>Asset Name: {asset?.name}</div>
-            <div>Playback URL: {asset?.playbackUrl}</div>
-            {uploadProgress && <div>Upload Progress: {Math.floor(uploadProgress * 100)}%</div>}
-            {asset?.status?.progress && <div>Processing Progress: {Math.floor(asset.status.progress * 100)}%</div>}
-          </>
-        )}
-        {error && <div>{error.message}</div>}
-      </div>
-    </LivepeerConfig>
-  ) 
-}
 ```
 
 </CodeBlockTabItem>
@@ -285,7 +264,16 @@ video file.
 
 You should use the `tusEndpoint` field of the
 [response object](/reference/api/create-asset#response-example) to upload the
-video file and track the progress:
+video file and track the progress.
+
+:::note 
+If you are using `tus` from `node.js`, you need to add a custom URL
+storage to enable resuming from previous uploads. On the browser, this is
+enabled by default using local storage. 
+
+In `node.js`, add `urlStorage: new tus.FileUrlStorage("path/to/tmp/file")`, to the `UploadFile`
+object definition.
+:::
 
 <CodeBlockTabs>
 <CodeBlockTabItem value="JavaScript" label="JavaScript">
@@ -321,9 +309,3 @@ upload.start();
 
 </CodeBlockTabItem>
 </CodeBlockTabs>
-
-> **Note:** If you are using `tus` from `node.js`, you need to add a custom URL
-> storage to enable resuming from previous uploads. On the browser, this is
-> enabled by default using local storage. In `node.js`, add
-> `urlStorage: new tus.FileUrlStorage("path/to/tmp/file")`, to the `UploadFile`
-> object definition above.

--- a/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/01-upload-video-asset/02-api.mdx
@@ -55,19 +55,6 @@ const uploadAssetURL = await fetch("https://livepeer.studio/api/asset/import", {
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request POST 'https://livepeer.studio/api/asset/import' \
---header 'Authorization: Bearer $API_TOKEN' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "url":"$EXTERNAL_URL",
-    "name":"Example name"
-}'
-```
-
-</CodeBlockTabItem>
 </CodeBlockTabs>
 
 ### Step 2: Check the upload status
@@ -94,14 +81,6 @@ const response = await fetch("https://livepeer.studio/api/asset/{id}", {
 });
 
 const { status } = await response.json();
-```
-
-</CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request GET 'https://livepeer.studio/api/asset/{id}' \
---header 'Authorization: Bearer $API_TOKEN'
 ```
 
 </CodeBlockTabItem>
@@ -142,18 +121,6 @@ const { url } = await response.json();
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request POST 'https://livepeer.studio/api/asset/request-upload' \
---header 'Authorization: Bearer $API_TOKEN' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "name":"Example name"
-}'
-```
-
-</CodeBlockTabItem>
 </CodeBlockTabs>
 
 ### Step 2: Upload your video to the URL
@@ -168,14 +135,6 @@ const upload = await fetch(url, {
   method: "PUT",
   body: fs.createReadStream(path),
 });
-```
-
-</CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request PUT "${url}" \
---data-binary '@$VIDEO_FILE_PATH'
 ```
 
 </CodeBlockTabItem>
@@ -204,14 +163,6 @@ const response = await fetch("https://livepeer.studio/api/asset/{id}", {
 });
 
 const { status } = await response.json();
-```
-
-</CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request GET 'https://livepeer.studio/api/asset/{id}' \
---header 'Authorization: Bearer $API_TOKEN'
 ```
 
 </CodeBlockTabItem>
@@ -321,18 +272,6 @@ const response = await fetch(
 );
 
 const { tusEndpoint } = await response.json();
-```
-
-</CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl --location --request POST 'https://livepeer.studio/api/asset/request-upload' \
---header 'Authorization: Bearer $API_TOKEN' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "name":"Example name"
-}'
 ```
 
 </CodeBlockTabItem>

--- a/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
@@ -29,58 +29,21 @@ Once you have an `asset.id`, you can make a request to update the asset's name,
 playback policy and storage.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
 
 ```js
-import {
-  LivepeerConfig,
-  createReactClient,
-  studioProvider,
-  useAsset, 
-  useUpdateAsset
-} from '@livepeer/react';
- 
-const client = createReactClient({
-  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
-});
- 
-const assetId = '7ce29561-91ae-42cf-b9c0-6e46dbc1cc2d';
+import { useUpdateAsset } from '@livepeer/react';
  
 function App() {
-  const { data: asset } = useAsset({
+  const { mutate: updateAsset } = useUpdateAsset({
     assetId,
-    refetchInterval: 10000,
+    name: 'testing123',
   });
-  const { mutate: updateAsset, status, error } = useUpdateAsset();
- 
-  return (
-    <LivepeerConfig client={client}>
-      <div>
-        <button
-          disabled={status === 'loading'}
-          onClick={() => {
-            updateAsset({
-              assetId,
-              name: "testing123",
-            });
-          }}
-        >
-          Upload to IPFS
-        </button>
-        {asset && (
-          <>
-            <div>Asset Name: {asset?.name}</div>
-          </>
-        )}
-        {error && <div>{error.message}</div>}
-      </div>
-    </LivepeerConfig>
-  );
 }
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const updateAssetName = await fetch("https://livepeer.studio/api/asset/{id}", {

--- a/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
@@ -49,20 +49,4 @@ const updateAssetData = await fetch("https://livepeer.studio/api/asset/{id}", {
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl -X PATCH https://livepeer.studio/api/asset/{id} \
--H 'content-type: application/json' \
--H 'authorization: Bearer $API_TOKEN' \
--d {
-    "name": "Example name",
-    "meta": {
-        "name": "testing123",
-        "description": "new video"
-    }
-}
-```
-
-</CodeBlockTabItem>
 </CodeBlockTabs>

--- a/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
+++ b/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
@@ -39,59 +39,21 @@ Once you have an `asset.id`, you can make a request to update the asset's
 storage location.
 
 <CodeBlockTabs>
-<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+<CodeBlockTabItem value="Livepeer.js" label="Livepeer.js">
 
 ```js
-import {
-  LivepeerConfig,
-  createReactClient,
-  studioProvider,
-  useAsset, 
-  useUpdateAsset
-} from '@livepeer/react';
- 
-const client = createReactClient({
-  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
-});
- 
-const assetId = '7ce29561-91ae-42cf-b9c0-6e46dbc1cc2d';
+import { useUpdateAsset } from '@livepeer/react';
  
 function App() {
-  const { data: asset } = useAsset({
+  const { mutate: updateAsset } = useUpdateAsset({
     assetId,
-    refetchInterval: 10000,
+    storage: { ipfs: true }
   });
-  const { mutate: updateAsset, status, error } = useUpdateAsset();
- 
-  return (
-    <LivepeerConfig client={client}>
-      <div>
-        <button
-          disabled={status === 'loading'}
-          onClick={() => {
-            updateAsset({
-              assetId,
-              storage: { ipfs: true },
-            });
-          }}
-        >
-          Upload to IPFS
-        </button>
-        {asset && (
-          <>
-            <div>Asset Name: {asset?.name}</div>
-            <div>IPFS CID: {asset?.storage?.ipfs?.cid ?? 'None'}</div>
-          </>
-        )}
-        {error && <div>{error.message}</div>}
-      </div>
-    </LivepeerConfig>
-  );
 }
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="JavaScript" label="JavaScript">
+<CodeBlockTabItem value="Fetch" label="Fetch">
 
 ```js
 const storeAssetOnIPFS = await fetch("https://livepeer.studio/api/asset/{id}", {

--- a/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
+++ b/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
@@ -109,14 +109,4 @@ const storeAssetOnIPFS = await fetch("https://livepeer.studio/api/asset/{id}", {
 ```
 
 </CodeBlockTabItem>
-<CodeBlockTabItem value="curl" label="curl">
-
-```bash
-curl -X PATCH https://livepeer.studio/api/asset/{id} \
--H 'content-type: application/json' \
--H 'authorization: Bearer $API_TOKEN' \
--d {"storage": {"ipfs": true}}
-```
-
-</CodeBlockTabItem>
 </CodeBlockTabs>

--- a/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
+++ b/docs/04-guides/on-demand/03-store-video-asset-on-ipfs/02-api.mdx
@@ -38,6 +38,58 @@ Once you have an `asset.id`, you can make a request to update the asset's
 storage location.
 
 <CodeBlockTabs>
+<CodeBlockTabItem value="Livepeerjs" label="Livepeerjs">
+
+```js
+import {
+  LivepeerConfig,
+  createReactClient,
+  studioProvider,
+  useAsset, 
+  useUpdateAsset
+} from '@livepeer/react';
+ 
+const client = createReactClient({
+  provider: studioProvider({ apiKey: 'yourStudioApiKey' }),
+});
+ 
+const assetId = '7ce29561-91ae-42cf-b9c0-6e46dbc1cc2d';
+ 
+function App() {
+  const { data: asset } = useAsset({
+    assetId,
+    refetchInterval: 10000,
+  });
+  const { mutate: updateAsset, status, error } = useUpdateAsset();
+ 
+  return (
+    <LivepeerConfig client={client}>
+      <div>
+        <button
+          disabled={status === 'loading'}
+          onClick={() => {
+            updateAsset({
+              assetId,
+              storage: { ipfs: true },
+            });
+          }}
+        >
+          Upload to IPFS
+        </button>
+        {asset && (
+          <>
+            <div>Asset Name: {asset?.name}</div>
+            <div>IPFS CID: {asset?.storage?.ipfs?.cid ?? 'None'}</div>
+          </>
+        )}
+        {error && <div>{error.message}</div>}
+      </div>
+    </LivepeerConfig>
+  );
+}
+```
+
+</CodeBlockTabItem>
 <CodeBlockTabItem value="JavaScript" label="JavaScript">
 
 ```js


### PR DESCRIPTION
resolves #245 

Changes
- Added Livepeerjs code example to `Get Viewer Engagement`, `Upload Video Asset`, `Update Video Asset`, and `Upload Asset to IPFS`
- removed curl blocks