### PR TITLE
on-demand: Remove references to deprecated/removed `meta` field

### DIFF
--- a/docs/04-guides/on-demand/02-update-video-asset/01-dashboard.mdx
+++ b/docs/04-guides/on-demand/02-update-video-asset/01-dashboard.mdx
@@ -12,7 +12,7 @@ import Tabs from "./_tabs.mdx";
 <Tabs />
 The Livepeer Studio Dashboard is a frontend interface for publishing live or on-demand
 video streams with no code. In this guide, we'll show you how to use the dashboard
-to update a video asset's name and metadata.
+to update a video asset's name.
 
 ## Step 1: Navigate to the [Assets page](https://livepeer.studio/dashboard/assets)
 
@@ -35,7 +35,7 @@ Click on `Edit Asset` to update an asset.
 
 ![Update asset](/../static/guides/Dashboard-7.png)
 
-Here you can update the asset's display name and metadata.
+Here you can update the asset's display name.
 
 ![Edit asset](/../static/guides/Dashboard-8.png)
 

--- a/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
+++ b/docs/04-guides/on-demand/02-update-video-asset/02-api.mdx
@@ -25,14 +25,14 @@ asset yet, you can follow the
 
 ## Step 2: Update the asset
 
-Once you have an `asset.id`, you can make a request to update the asset's name
-and metadata.
+Once you have an `asset.id`, you can make a request to update the asset's name,
+playback policy and storage.
 
 <CodeBlockTabs>
 <CodeBlockTabItem value="JavaScript" label="JavaScript">
 
 ```js
-const updateAssetData = await fetch("https://livepeer.studio/api/asset/{id}", {
+const updateAssetName = await fetch("https://livepeer.studio/api/asset/{id}", {
   method: "PATCH",
   headers: {
     Authorization: `Bearer ${process.env.API_TOKEN}`,
@@ -40,10 +40,6 @@ const updateAssetData = await fetch("https://livepeer.studio/api/asset/{id}", {
   },
   body: {
     name: "testing123",
-    meta: {
-      name: "testing123",
-      description: "new video",
-    },
   },
 });
 ```
@@ -55,13 +51,7 @@ const updateAssetData = await fetch("https://livepeer.studio/api/asset/{id}", {
 curl -X PATCH https://livepeer.studio/api/asset/{id} \
 -H 'content-type: application/json' \
 -H 'authorization: Bearer $API_TOKEN' \
--d {
-    "name": "Example name",
-    "meta": {
-        "name": "testing123",
-        "description": "new video"
-    }
-}
+-d '{ "name": "Example name" }'
 ```
 
 </CodeBlockTabItem>

--- a/docs/05-reference/api/create-asset.mdx
+++ b/docs/05-reference/api/create-asset.mdx
@@ -65,13 +65,7 @@ const response = await fetch("https://livepeer.studio/api/asset/request-upload",
       type: <code>string</code>,
       description:
         "The name of the `Asset` containing a custom human-readable description or title.",
-    },
-    {
-      parameter: <code>meta</code>,
-      type: <code>object</code>,
-      description:
-        "Object with `string` keys and values for any metadata you want to associate with the asset (e.g. content tags).",
-    },
+    }
   ]}
 /> -->
 

--- a/docs/05-reference/api/update-asset.mdx
+++ b/docs/05-reference/api/update-asset.mdx
@@ -10,7 +10,6 @@ mutable properties of an asset:
 
 - `name`
 - `storage`
-- `meta`
 
 ## Update Stored Asset
 
@@ -36,8 +35,9 @@ stored.
 
 - Currently assets cannot be deleted from the default Livepeer Studio storage.
   You can customize any additional storage though.
-- Only IPFS is supported as an additional storage at the moment. We are currently
-  working on support for other decentralized storages like Arweave and Storj.
+- Only IPFS is supported as an additional storage at the moment. We are
+  currently working on support for other decentralized storages like Arweave and
+  Storj.
 
 ### Request
 
@@ -48,31 +48,48 @@ curl -X PATCH https://livepeer.studio/api/asset/{id} \
 -d {"storage": {"ipfs": {}}}
 ```
 
-## Updating Metadata
+### Response
 
-This allows for modifying the metadata of the asset, which is customizable NFT.
+Storing a file on IPFS is a long-running operation, which can take a few seconds
+to complete. As such, you won't get an immediate result on the response, but
+should check the `storage.status` object of the asset (e.g. polling) until it
+phases to `ready`. Then you will have the corresponding CIDs of the asset inside
+the `storage.ipfs` object.
+
+You can also use the `asset.updated` webhook to get notified when the asset
+changes, both for the intermediate progress updates and the final update with
+the CIDs added to the object.
+
+## Setting NFT Metadata
+
+When you save a file to IPFS Livepeer Studio also exports a metadata file that
+can be used to mint NFTs from the video. This way you don't need to have a
+separate IPFS provider only for storing your NFT metadata.
+
 Since each marketplace has their own standard for the `metadata` of the NFT, it
 is up to you to determine which standard to use and fields to include.
 
 > **NOTE:**
 
-- Livepeer Studio's default fields for `metadata` are:
+- Livepeer Studio injects a couple of fields by default in the final NFT
+  metadata saved on IPFS:
 
 ```json
-    "name": , //Populated with the asset name
-    "description": , //A default description referring to the asset name above
-    "image": //A default image including the Livepeer logo as a thumbnail
-    "animation_url": //URL for the Livepeer player on IPFS playing the video from Livepeer Studio
-    "external_url": //URL for the Livepeer player hosted on lvpr.tv playing the video from Livepeer Studio
+    "name": , // Populated with the same name of the asset in the API
+    "description": , // A default description referring to the above asset name
+    "image": // A default image including the Livepeer logo as a thumbnail
+    "animation_url": // IPFS URL for an immutable version of the lvpr.tv player with the video
+    "external_url": // Mutable URL for the lvpr.tv player with the video
     "properties": {
-      "video": //CID of the original video file saved on IPFS
-      "com.livepeer.playbackId": //playback ID of the asset in Livepeer Studio
+      "video": // CID of the original video file saved on IPFS
+      "com.livepeer.playbackId": // playback ID of the asset in Livepeer Studio
     }
 ```
 
 > **NOTICE** that you can change the value or delete any of these default fields
-> by providing a value in the `nftMetadata` field. You can delete any of the
-> above fields by specifying them as `null` in your overrides.
+> by providing a value for it in the `nftMetadata` object, which have precedence
+> over whatever is set by default. You can delete any of the above fields by
+> specifying them as `null` in your overrides.
 
 Example: `"animation_url": null`
 
@@ -82,19 +99,30 @@ Example: `"animation_url": null`
 curl -X PATCH https://livepeer.studio/api/asset/{id} \
 -H 'content-type: application/json' \
 -H 'authorization: Bearer {api-key}' \
--d {  "meta": {
-        "title": "My awesome video",
-        "description": "This is a video of my awesome life",
-        "tags": "awesome,life,video"
-    }
-  }
+-d '{
+      "storage": {
+        "ipfs": {
+          "spec": {
+            "nftMetadata": {
+              "title": "My awesome video",
+              "description": "This is a video of my awesome life",
+              "tags": "awesome,life,video"
+            }
+          }
+        }
+      }
+    }'
 ```
+
+### Response
+
+Same as before, saving the NFT metadata on IPFS will be a long-running
+operation. You can track the progress the same way as the simple IPFS request,
+with the NFT metadata CID showing up in the `storage.ipfs.nftMetadata` object.
 
 ## Updating Multiple parameters
 
-This allows for modifying the metadata of the asset, which can be used to
-customize the asset of the NFT metadata. These fields are customizable and are
-not set.
+You can also specify multiple fields to update in a single `PATCH` request.
 
 ### Request
 
@@ -104,12 +132,7 @@ curl -X PATCH https://livepeer.studio/api/asset/{id} \
 -H 'authorization: Bearer {api-key}' \
 -d {
   "name": "New name",
-  "storage": {"ipfs": {}},
-  "meta": {
-        "title": "My awesome video",
-        "description": "This is a video of my awesome life",
-        "tags": "awesome,life,video"
-    }
+  "storage": {"ipfs": {}}
   }
 ```
 

--- a/docs/05-reference/api/update-asset.mdx
+++ b/docs/05-reference/api/update-asset.mdx
@@ -71,8 +71,8 @@ is up to you to determine which standard to use and fields to include.
 
 > **NOTE:**
 
-- Livepeer Studio injects a couple of fields by default in the final NFT
-  metadata saved on IPFS:
+- Livepeer Studio includes a couple of fields by default which are deep merged
+  with the provided NFT metadata, with the provided values having precedence.
 
 ```json
     "name": , // Populated with the same name of the asset in the API


### PR DESCRIPTION
This is to fix docs that referred to the asset `meta` field, since it does not exist anymore!

We realized that no user was actually using it, and it was only complicating our whole 
NFT metadata situation. So we better remove that for now and we can consider adding it
back if it ever seems useful (it might never be lol).

lfg